### PR TITLE
Return an array instead of undefined when no header is present

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 module.exports = function parseWarningHeader (header) {
   if (!header || typeof header !== 'string') return
   var warnings = header.split(/([0-9]{3} [a-z0-9.@\-\/]*) /g)
-  if (!warnings) return
 
   var previous
   function generateObject (all, w) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = function parseWarningHeader (header) {
-  if (!header || typeof header !== 'string') return
+  if (!header || typeof header !== 'string') return []
   var warnings = header.split(/([0-9]{3} [a-z0-9.@\-\/]*) /g)
 
   var previous

--- a/test.js
+++ b/test.js
@@ -14,3 +14,10 @@ assert.deepEqual(warnings[1], {code: '299', agent: 'agent2', message: 'Error mes
 // HTTP-Date format support https://tools.ietf.org/html/rfc7231#section-7.1.1.1
 var httpDate = parse('199 agent "Error message" "Sun, 06 Nov 1994 08:49:37 GMT"')
 assert.deepEqual(httpDate[0], {code: '199', agent: 'agent', message: 'Error message', date: 'Sun, 06 Nov 1994 08:49:37 GMT'})
+
+// Returns an empty array for invalid headers
+assert.equal(Array.isArray(parse()), true)
+assert.equal(parse().length, 0)
+
+assert.equal(Array.isArray(parse('')), true)
+assert.equal(parse('').length, 0)


### PR DESCRIPTION
This pr a breaking change. We're now returning `[]` instead of `undefined` when no warning header is present.

This pr closes #2 